### PR TITLE
Feature/query performance improvement

### DIFF
--- a/src/main/java/com/codingmate/answer/domain/Answer.java
+++ b/src/main/java/com/codingmate/answer/domain/Answer.java
@@ -59,6 +59,7 @@ public class Answer extends BaseEntity {
                 .languageType(request.languageType())
                 .programmer(programmer)
                 .backJoonId(request.backjoonId())
+                .likeCount(0)
                 .build();
     }
 

--- a/src/main/java/com/codingmate/answer/repository/AnswerReadRepository.java
+++ b/src/main/java/com/codingmate/answer/repository/AnswerReadRepository.java
@@ -33,7 +33,6 @@ import static com.codingmate.answer.domain.QAnswer.answer;
 public class AnswerReadRepository {
     private final JPAQueryFactory queryFactory;
 
-    @Transactional(readOnly = true)
     public Optional<Answer> read(Long answerId) {
         return Optional.ofNullable(
                 queryFactory.selectFrom(answer)
@@ -48,7 +47,6 @@ public class AnswerReadRepository {
      * @implNote fetchOne은 null을 반환할 수 있다.
      * @implSpec answer.count를 사용해서 숫자를 가져오도록 한다.
      * */
-    @Transactional(readOnly = true)
     public long countProgrammerWroteAnswer(Long programmerId) {
         Long count = queryFactory.select(answer.count())
                 .from(answer)
@@ -57,7 +55,7 @@ public class AnswerReadRepository {
         return count != null ? count : 0L;
     }
 
-    @Transactional(readOnly = true)
+
     public Page<AnswerListResponse> readAll(LanguageType languageType, Long backjoonId, Pageable pageable) {
 
         // 1. 실제 데이터를 조회하는 쿼리 실행
@@ -101,7 +99,7 @@ public class AnswerReadRepository {
         return backjoonId != null ? answer.backJoonId.eq(backjoonId) : null;
     }
 
-    @Transactional(readOnly = true)
+
     public Page<AnswerListResponse> readAllByProgrammerId(LanguageType languageType, Long backjoonId, Long programmerId, Pageable pageable) {
         List<AnswerListResponse> content = queryFactory.select(new QAnswerListResponse(answer.id, answer.backJoonId, answer.title, answer.programmer.name.name, answer.languageType))
                 .from(answer)

--- a/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
+++ b/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
@@ -24,8 +24,10 @@ public class AnswerWriteRepository {
     @Transactional
     public long update(Long programmerId, Long answerId, AnswerUpdateRequest dto) {
         return queryFactory.update(answer)
-                .where(answer.id.eq(answerId))
-                .where(answer.programmer.id.eq(programmerId))
+                .where(
+                        answer.id.eq(answerId),
+                        answer.programmer.id.eq(programmerId)
+                )
                 .set(answer.code, dto.code() == null ? null : dto.code())
                 .set(answer.languageType, dto.languageType() == null ? null : dto.languageType())
                 .set(answer.explanation, dto.explanation() == null ? null : dto.explanation())

--- a/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
+++ b/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
@@ -21,7 +21,6 @@ import static com.codingmate.answer.domain.QAnswer.answer;
 public class AnswerWriteRepository {
     private final JPAQueryFactory queryFactory;
 
-    @Transactional
     public long update(Long programmerId, Long answerId, AnswerUpdateRequest dto) {
         return queryFactory.update(answer)
                 .where(
@@ -35,7 +34,6 @@ public class AnswerWriteRepository {
                 .execute();
     }
 
-    @Transactional
     public long deleteByProgrammerId(Long id) {
         return queryFactory.delete(answer)
                 .where(answer.programmer.id.eq(id))

--- a/src/main/java/com/codingmate/answer/service/AnswerService.java
+++ b/src/main/java/com/codingmate/answer/service/AnswerService.java
@@ -46,7 +46,7 @@ public class AnswerService {
      * @param programmerId Answer를 작성할 Programmer의 ID
      * @param request      생성할 Answer의 내용을 담은 DTO
      * @return 생성된 Answer의 ID를 포함하는 응답 DTO
-     * @throws com.codingmate.exception.exception.programmer.NotFoundProgrammerException 지정된 {@code programmerId}를 가진 Programmer를 찾을 수 없을 경우 발생합니다.
+     * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 Programmer를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional
     public AnswerCreateResponse create(Long programmerId, AnswerCreateRequest request) {
@@ -77,7 +77,7 @@ public class AnswerService {
      * @param answerId   조회할 Answer의 ID
      * @param programmerId 현재 요청을 보낸 Programmer의 ID (좋아요 여부 확인용)
      * @return Answer 상세 정보와 좋아요 여부를 포함하는 응답 DTO
-     * @throws com.codingmate.exception.exception.answer.NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없을 경우 발생합니다.
+     * @throws NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional(readOnly = true)
     public AnswerPageResponse read(Long answerId, Long programmerId) {
@@ -141,7 +141,7 @@ public class AnswerService {
      * @param programmerId 수정 요청을 보낸 Programmer의 ID (권한 확인용)
      * @param answerId     수정할 Answer의 ID
      * @param request      업데이트할 내용을 담은 DTO
-     * @throws com.codingmate.exception.exception.answer.NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없거나, 수정 권한이 없을 경우 발생합니다.
+     * @throws NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없거나, 수정 권한이 없을 경우 발생합니다.
      */
     @Transactional
     public void update(Long programmerId, Long answerId, AnswerUpdateRequest request) {
@@ -166,8 +166,8 @@ public class AnswerService {
      *
      * @param programmerId 삭제 요청을 보낸 Programmer의 ID
      * @param answerId     삭제할 Answer의 ID
-     * @throws com.codingmate.exception.exception.answer.NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없을 경우 발생합니다.
-     * @throws com.codingmate.exception.exception.answer.AnswerAndProgrammerDoNotMatchException 삭제 요청을 보낸 Programmer가 해당 Answer의 작성자가 아닐 경우 발생합니다.
+     * @throws NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없을 경우 발생합니다.
+     * @throws AnswerAndProgrammerDoNotMatchException 삭제 요청을 보낸 Programmer가 해당 Answer의 작성자가 아닐 경우 발생합니다.
      */
     @Transactional
     public void delete(Long programmerId, Long answerId) {

--- a/src/main/java/com/codingmate/aop/timelog/ExecutionTimeLogger.java
+++ b/src/main/java/com/codingmate/aop/timelog/ExecutionTimeLogger.java
@@ -1,0 +1,29 @@
+package com.codingmate.aop.timelog;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class ExecutionTimeLogger {
+
+    @Around("@annotation(com.codingmate.aop.timelog.LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        Object result = null;
+        String methodName = joinPoint.getSignature().toShortString();
+        try {
+            log.debug("[SYSTEM] {}({}) start", methodName, joinPoint.getArgs());
+            result = joinPoint.proceed();  // 실제 메서드 실행
+            return result;
+        } finally {
+            long time = System.currentTimeMillis() - start;
+            log.debug("[SYSTEM] {} executed in {} ms", methodName, time);
+        }
+    }
+}

--- a/src/main/java/com/codingmate/aop/timelog/LogExecutionTime.java
+++ b/src/main/java/com/codingmate/aop/timelog/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package com.codingmate.aop.timelog;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+}

--- a/src/main/java/com/codingmate/auth/service/LoginService.java
+++ b/src/main/java/com/codingmate/auth/service/LoginService.java
@@ -31,8 +31,8 @@ public class LoginService {
      * @param loginId  사용자 로그인 ID
      * @param password 사용자 비밀번호
      * @return 로그인에 성공하면 해당 Programmer의 정보를 담은 ProgrammerResponse 객체를 반환합니다.
-     * @throws com.codingmate.exception.exception.programmer.LoginIdNotMatchException 요청한 {@code loginId}에 해당하는 사용자를 찾을 수 없을 경우 발생합니다.
-     * @throws com.codingmate.exception.exception.programmer.PasswordNotMatchException 요청한 {@code password}가 해당 사용자의 비밀번호와 일치하지 않을 경우 발생합니다.
+     * @throws LoginIdNotMatchException 요청한 {@code loginId}에 해당하는 사용자를 찾을 수 없을 경우 발생합니다.
+     * @throws PasswordNotMatchException 요청한 {@code password}가 해당 사용자의 비밀번호와 일치하지 않을 경우 발생합니다.
      */
     @Transactional(readOnly = true)
     public ProgrammerResponse login(String loginId, String password) {

--- a/src/main/java/com/codingmate/programmer/repository/ProgrammerReadRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/ProgrammerReadRepository.java
@@ -31,7 +31,6 @@ public class ProgrammerReadRepository {
      *           * limit 1을 사용해서 1개를 찾으면 쿼리를 중단하도록 함
      * @implSpec CREATE INDEX idx_programmer_login_id ON programmer(login_id); 인덱스를 만들어둠
      * */
-    @Transactional(readOnly = true)
     public boolean isExistLoginId(String loginId) {
         return queryFactory.selectOne()
                 .from(programmer)
@@ -43,7 +42,6 @@ public class ProgrammerReadRepository {
     /**
      * @implSpec fetchJoin으로 지연로딩 방지
      * */
-    @Transactional(readOnly = true)
     public Optional<Programmer> readByLoginId(String loginId) {
         return Optional.ofNullable(
                 queryFactory.selectFrom(programmer)
@@ -57,7 +55,6 @@ public class ProgrammerReadRepository {
     /**
      * @implSpec fetchJoin으로 지연로딩 방지
      * */
-    @Transactional(readOnly = true)
     public Optional<String> readProgrammerRole (Long programmerId) {
         Programmer result = queryFactory.selectFrom(programmer)
                 .where(programmer.id.eq(programmerId))

--- a/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
@@ -35,7 +35,6 @@ public class ProgrammerWriteRepository {
      * @implSpec loginId가 중복되는지 여부 확인 + Programmer 등록으로 쿼리가 두 번 나감
      * @implNote em.persist는 항상 값을 반환하기 때문에 Optional을 사용하지 않는다.
      * */
-    @Transactional
     public ProgrammerResponse create(ProgrammerCreateRequest request, Authority authority) {
         log.info(request.toString());
         var entity = Programmer.toEntity(request, authority);
@@ -44,7 +43,6 @@ public class ProgrammerWriteRepository {
         return ProgrammerResponse.of(entity);
     }
 
-    @Transactional
     public long update(Long programmerId, ProgrammerUpdateRequest dto) {
         return queryFactory.update(programmer)
                 .where(programmer.id.eq(programmerId))

--- a/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
@@ -36,10 +36,9 @@ public class ProgrammerWriteRepository {
      * @implNote em.persist는 항상 값을 반환하기 때문에 Optional을 사용하지 않는다.
      * */
     public ProgrammerResponse create(ProgrammerCreateRequest request, Authority authority) {
-        log.info(request.toString());
         var entity = Programmer.toEntity(request, authority);
         em.persist(entity);
-        log.info(entity.toString());
+
         return ProgrammerResponse.of(entity);
     }
 

--- a/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
@@ -5,6 +5,7 @@ import com.codingmate.common.annotation.Explanation;
 import com.codingmate.programmer.domain.Programmer;
 import com.codingmate.programmer.dto.request.ProgrammerCreateRequest;
 import com.codingmate.programmer.dto.request.ProgrammerUpdateRequest;
+import com.codingmate.programmer.dto.response.ProgrammerResponse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.AccessLevel;
@@ -32,14 +33,15 @@ public class ProgrammerWriteRepository {
 
     /**
      * @implSpec loginId가 중복되는지 여부 확인 + Programmer 등록으로 쿼리가 두 번 나감
+     * @implNote em.persist는 항상 값을 반환하기 때문에 Optional을 사용하지 않는다.
      * */
     @Transactional
-    public Optional<Programmer> create(ProgrammerCreateRequest request, Authority authority) {
+    public ProgrammerResponse create(ProgrammerCreateRequest request, Authority authority) {
         log.info(request.toString());
         var entity = Programmer.toEntity(request, authority);
         em.persist(entity);
         log.info(entity.toString());
-        return Optional.of(entity);
+        return ProgrammerResponse.of(entity);
     }
 
     @Transactional

--- a/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
+++ b/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
@@ -9,7 +9,6 @@ import com.codingmate.programmer.dto.response.MyPageResponse;
 import com.codingmate.exception.dto.ErrorMessage;
 import com.codingmate.exception.exception.programmer.DuplicateProgrammerLoginIdException;
 import com.codingmate.exception.exception.programmer.NotFoundProgrammerException;
-import com.codingmate.exception.exception.programmer.ProgrammerNotCreateException;
 import com.codingmate.programmer.repository.DefaultProgrammerRepository;
 import com.codingmate.programmer.repository.ProgrammerReadRepository;
 import com.codingmate.programmer.repository.ProgrammerWriteRepository;
@@ -18,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.webjars.NotFoundException;
 
 @Slf4j
 @Service
@@ -36,8 +34,7 @@ public class ProgrammerService {
      * 계정 생성 전에 로그인 ID의 중복 여부를 확인합니다.
      *
      * @param request 생성할 프로그래머의 정보를 담은 DTO
-     * @throws com.codingmate.exception.exception.programmer.DuplicateProgrammerLoginIdException 요청한 {@code loginId}가 이미 존재할 경우 발생합니다.
-     * @throws com.codingmate.exception.exception.programmer.ProgrammerNotCreateException 프로그래머 생성 중 예상치 못한 오류가 발생하여 계정이 생성되지 않았을 경우 발생합니다.
+     * @throws DuplicateProgrammerLoginIdException 요청한 {@code loginId}가 이미 존재할 경우 발생합니다.
      */
     @Transactional
     public void create(ProgrammerCreateRequest request) {
@@ -66,7 +63,7 @@ public class ProgrammerService {
      * 주어진 로그인 ID의 사용 가능 여부를 확인합니다.
      *
      * @param loginId 확인할 로그인 ID
-     * @throws com.codingmate.exception.exception.programmer.DuplicateProgrammerLoginIdException 요청한 {@code loginId}가 이미 존재하여 사용할 수 없을 경우 발생합니다.
+     * @throws DuplicateProgrammerLoginIdException 요청한 {@code loginId}가 이미 존재하여 사용할 수 없을 경우 발생합니다.
      */
     @Transactional(readOnly = true)
     public void checkLoginIdAvailability(String loginId) {
@@ -88,7 +85,7 @@ public class ProgrammerService {
      *
      * @param programmerId 조회할 프로그래머의 ID
      * @return 프로그래머의 마이페이지 정보를 담은 응답 DTO
-     * @throws com.codingmate.exception.exception.programmer.NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
+     * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional(readOnly = true)
     public MyPageResponse getProgrammerMyPageInfo(Long programmerId) {
@@ -131,7 +128,7 @@ public class ProgrammerService {
      *
      * @param programmerId 업데이트할 프로그래머의 ID
      * @param request      업데이트할 내용을 담은 DTO
-     * @throws com.codingmate.exception.exception.programmer.NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
+     * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional
     public void update(Long programmerId, ProgrammerUpdateRequest request) {
@@ -155,7 +152,7 @@ public class ProgrammerService {
      * 계정 삭제 시, 해당 프로그래머가 작성한 모든 답변도 함께 삭제됩니다.
      *
      * @param programmerId 삭제할 프로그래머의 ID
-     * @throws com.codingmate.exception.exception.programmer.NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
+     * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional
     public void delete(Long programmerId) {

--- a/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
+++ b/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
@@ -54,13 +54,10 @@ public class ProgrammerService {
         log.debug("[ProgrammerService] Login ID {} is available.", request.loginId());
 
 
-        writeRepository.create(request, authorityFinder.getUserAuthority("ROLE_USER"))
-                .orElseThrow(() -> {
-                    log.error("[ProgrammerService] Programmer creation failed for loginId: {}. Database write issue?", request.loginId());
-                    return new ProgrammerNotCreateException(
-                            ErrorMessage.PROGRAMMER_NOT_CREATED,
-                            "요청에 따른 PROGRAMMER가 생성되지 않았습니다.");
-                });
+        writeRepository.create(
+                request,
+                authorityFinder.getUserAuthority("ROLE_USER")
+        );
 
         log.info("[ProgrammerService] Programmer created successfully with loginId: {}", request.loginId());
     }

--- a/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
+++ b/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
@@ -102,13 +102,13 @@ public class ProgrammerService {
                             ErrorMessage.INVALID_ID,
                             String.format("%d는 존재하지 않는 ProgrammerID입니다.", programmerId));
                 });
-        log.debug("[ProgrammerService] Programmer found: {}. Counting answers...", programmer.getId());
+        log.debug("[ProgrammerService] Programmer found: {}. Counting answers...", programmerId);
 
-        long wroteAnswersCount = answerReadRepository.countProgrammerWroteAnswer(programmerId);
-        log.debug("[ProgrammerService] Programmer {} has written {} answers.", programmerId, wroteAnswersCount);
+        long writtenAnswersCount = answerReadRepository.countProgrammerWroteAnswer(programmerId);
+        log.debug("[ProgrammerService] Programmer {} has written {} answers.", programmerId, writtenAnswersCount);
         log.info("[ProgrammerService] Successfully retrieved MyPage info for programmerId: {}", programmerId);
 
-        return MyPageResponse.of(programmer, wroteAnswersCount);
+        return MyPageResponse.of(programmer, writtenAnswersCount);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenReadRepository.java
+++ b/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenReadRepository.java
@@ -22,22 +22,29 @@ public class RefreshTokenReadRepository {
     private final JPAQueryFactory queryFactory;
 
     @Transactional(readOnly = true)
-    public Long countRefreshToken(Long userId) {
+    public long countRefreshToken(Long userId) {
         Long count = queryFactory
                 .select(refreshToken.count())
                 .from(refreshToken)
-                .where(refreshToken.userId.eq(userId))
-                .where(refreshToken.isRevoked.eq(false))
+                .where(
+                        refreshToken.userId.eq(userId),
+                        refreshToken.isRevoked.eq(false)
+                )
                 .fetchOne();
 
         return count == null ? 0 : count;
     }
 
+    /**
+     * @implNote isRevoked는 null을 반환할 수 있기 때문에 체크 후 리턴
+     * */
     @Transactional(readOnly = true)
-    public Boolean isUsedJti(String jti) {
-        return queryFactory.select(refreshToken.isRevoked)
+    public boolean isUsedJti(String jti) {
+        Boolean isRevoked = queryFactory.select(refreshToken.isRevoked)
                 .from(refreshToken)
                 .where(refreshToken.jti.eq(jti))
                 .fetchOne();
+
+        return Boolean.TRUE.equals(isRevoked);
     }
 }

--- a/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenReadRepository.java
+++ b/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenReadRepository.java
@@ -21,7 +21,6 @@ import static com.codingmate.refreshtoken.domain.QRefreshToken.refreshToken;
 public class RefreshTokenReadRepository {
     private final JPAQueryFactory queryFactory;
 
-    @Transactional(readOnly = true)
     public long countRefreshToken(Long userId) {
         Long count = queryFactory
                 .select(refreshToken.count())
@@ -38,7 +37,6 @@ public class RefreshTokenReadRepository {
     /**
      * @implNote isRevoked는 null을 반환할 수 있기 때문에 체크 후 리턴
      * */
-    @Transactional(readOnly = true)
     public boolean isUsedJti(String jti) {
         Boolean isRevoked = queryFactory.select(refreshToken.isRevoked)
                 .from(refreshToken)

--- a/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenWriteRepository.java
+++ b/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenWriteRepository.java
@@ -20,7 +20,6 @@ import static com.codingmate.refreshtoken.domain.QRefreshToken.refreshToken;
 public class RefreshTokenWriteRepository {
     private final JPAQueryFactory queryFactory;
 
-    @Transactional
     public long revokeAllToken(Long userId) {
         return queryFactory.update(refreshToken)
                 .where(

--- a/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenWriteRepository.java
+++ b/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenWriteRepository.java
@@ -23,8 +23,10 @@ public class RefreshTokenWriteRepository {
     @Transactional
     public long revokeAllToken(Long userId) {
         return queryFactory.update(refreshToken)
-                .where(refreshToken.userId.eq(userId))
-                .where(refreshToken.isRevoked.eq(false))
+                .where(
+                        refreshToken.userId.eq(userId),
+                        refreshToken.isRevoked.eq(false)
+                )
                 .set(refreshToken.isRevoked, true)
                 .execute();
     }

--- a/src/main/java/com/codingmate/refreshtoken/service/RefreshTokenService.java
+++ b/src/main/java/com/codingmate/refreshtoken/service/RefreshTokenService.java
@@ -81,7 +81,7 @@ public class RefreshTokenService {
      * */
     private void validateMaxTokenCount(Long programmerId){
         log.debug("[RefreshTokenService] Checking token count for user: {}", programmerId);
-        Long count = refreshTokenReadRepository.countRefreshToken(programmerId);
+        long count = refreshTokenReadRepository.countRefreshToken(programmerId);
         log.info("[RefreshTokenService] Token count: {}", count);
         if (count > MAX_TOKEN) {
             throw new RefreshTokenOverMax(


### PR DESCRIPTION
### 📝 요약 (Summary)

이 PR은 Querydsl을 사용한 조회를 최적화하기 위한 브랜치입니다.

---

### 🚀 변경 배경 및 문제점 (Motivation / Problem Solved)

기존의 쿼리는 빠른 개발을 위해 목적 달성만을 생각하며 빠르게 작성하였기 때문에 최적화가 한 번 필요했습니다.
그래서 브랜치를 따로 만들어 최적화를 진행하였습니다.

---

### 🛠️ 변경 내용 상세 (Changes Made)

* 데이터베이스 인덱스를 생성하여 인덱스를 사용할 수 있도록 하였습니다.
* Querydsl의 where 절을 한 번만 사용하도록 리펙토링 하였습니다. 기존에는 여러 번 where을 사용하여 가독성이 떨어지는 경향이 있었습니다.

---

### 💡 구현 세부 사항 및 기술적 결정 (Implementation Details / Technical Decisions)

데이터베이스에 인덱스를 사용해서 PK가 아닌 값으로 조회할 때도 빠르게 조회할 수 있도록 하였습니다. 이는 리프레쉬 토큰을 데이터베이스에 저장해 블랙리스트를 구현할 때 블랙리스트를 확인하는 용도로 사용되었습니다.

