### PR TITLE
feat: JWT와 SecurityContextHolder를 사용하여 인증 정보 저장

### DIFF
--- a/src/main/java/com/codingmate/answer/dto/response/AnswerPageResponse.java
+++ b/src/main/java/com/codingmate/answer/dto/response/AnswerPageResponse.java
@@ -63,11 +63,11 @@ public record AnswerPageResponse(
          * Answer 엔티티와 추가 정보를 사용하여 AnswerPageResponse를 생성합니다.
          *
          * @param answer              응답으로 변환할 Answer 엔티티
-         * @param requestProgrammerId 현재 요청을 보낸 프로그래머의 ID (로그인하지 않은 경우 null)
+         * @param username 현재 요청을 보낸 프로그래머의 ID (로그인하지 않은 경우 null)
          * @param isLiked             현재 요청을 보낸 프로그래머가 이 답변을 추천했는지 여부
          * @return AnswerPageResponse 객체
          */
-        public static AnswerPageResponse of(Answer answer, Long requestProgrammerId, Boolean isLiked) {
+        public static AnswerPageResponse of(Answer answer, String username, Boolean isLiked) {
                 return AnswerPageResponse.builder()
                         .id(answer.getId())
                         .backjoonId(answer.getBackJoonId())
@@ -78,7 +78,7 @@ public record AnswerPageResponse(
                         .programmerId(answer.getProgrammer().getId())
                         .languageType(answer.getLanguageType())
                         .programmerName(answer.getProgrammer().getName().getName())
-                        .isRequesterIsOwner(Objects.equals(requestProgrammerId, answer.getProgrammer().getId()))
+                        .isRequesterIsOwner(Objects.equals(username, answer.getProgrammer().getLoginId()))
                         .isLiked(isLiked)
                         .build();
         }

--- a/src/main/java/com/codingmate/answer/repository/AnswerReadRepository.java
+++ b/src/main/java/com/codingmate/answer/repository/AnswerReadRepository.java
@@ -59,10 +59,15 @@ public class AnswerReadRepository {
 
         // 1. 실제 데이터를 조회하는 쿼리 실행
         List<AnswerListResponse> content = queryFactory
-                .select(new QAnswerListResponse(answer.id, answer.backJoonId, answer.title, answer.programmer.name.name, answer.languageType))
+                .select(new QAnswerListResponse(
+                        answer.id,
+                        answer.backJoonId,
+                        answer.title,
+                        answer.programmer.name.name,
+                        answer.languageType)
+                )
                 .from(answer)
                 .join(answer.programmer) // join을 .from() 바로 아래에 두는 것이 일반적
-                .fetchJoin()
                 .where(
                         languageTypeEq(languageType), // 조건 메서드 사용
                         backjoonIdEq(backjoonId)     // 조건 메서드 사용
@@ -100,10 +105,17 @@ public class AnswerReadRepository {
 
 
     public Page<AnswerListResponse> readAllByProgrammerId(LanguageType languageType, Long backjoonId, String loginId, Pageable pageable) {
-        List<AnswerListResponse> content = queryFactory.select(new QAnswerListResponse(answer.id, answer.backJoonId, answer.title, answer.programmer.name.name, answer.languageType))
+        List<AnswerListResponse> content = queryFactory.select(
+                        new QAnswerListResponse(
+                                answer.id,
+                                answer.backJoonId,
+                                answer.title,
+                                answer.programmer.name.name,
+                                answer.languageType
+                        )
+                )
                 .from(answer)
                 .join(answer.programmer)
-                .fetchJoin()
                 .where(
                         answer.programmer.loginId.eq(loginId),
                         languageTypeEq(languageType),

--- a/src/main/java/com/codingmate/answer/repository/AnswerReadRepository.java
+++ b/src/main/java/com/codingmate/answer/repository/AnswerReadRepository.java
@@ -46,10 +46,10 @@ public class AnswerReadRepository {
      * @implNote fetchOne은 null을 반환할 수 있다.
      * @implSpec answer.count를 사용해서 숫자를 가져오도록 한다.
      * */
-    public long countProgrammerWroteAnswer(Long programmerId) {
+    public long countProgrammerWroteAnswer(String loginId) {
         Long count = queryFactory.select(answer.count())
                 .from(answer)
-                .where(answer.programmer.id.eq(programmerId))
+                .where(answer.programmer.loginId.eq(loginId))
                 .fetchOne();
         return count != null ? count : 0L;
     }
@@ -99,13 +99,13 @@ public class AnswerReadRepository {
     }
 
 
-    public Page<AnswerListResponse> readAllByProgrammerId(LanguageType languageType, Long backjoonId, Long programmerId, Pageable pageable) {
+    public Page<AnswerListResponse> readAllByProgrammerId(LanguageType languageType, Long backjoonId, String loginId, Pageable pageable) {
         List<AnswerListResponse> content = queryFactory.select(new QAnswerListResponse(answer.id, answer.backJoonId, answer.title, answer.programmer.name.name, answer.languageType))
                 .from(answer)
                 .join(answer.programmer)
                 .fetchJoin()
                 .where(
-                        answer.programmer.id.eq(programmerId),
+                        answer.programmer.loginId.eq(loginId),
                         languageTypeEq(languageType),
                         backjoonIdEq(backjoonId)
                 )

--- a/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
+++ b/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
@@ -34,9 +34,9 @@ public class AnswerWriteRepository {
                 .execute();
     }
 
-    public long deleteByProgrammerId(Long id) {
+    public long deleteByLoginId(String loginId) {
         return queryFactory.delete(answer)
-                .where(answer.programmer.id.eq(id))
+                .where(answer.programmer.loginId.eq(loginId))
                 .execute();
     }
 }

--- a/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
+++ b/src/main/java/com/codingmate/answer/repository/AnswerWriteRepository.java
@@ -21,11 +21,11 @@ import static com.codingmate.answer.domain.QAnswer.answer;
 public class AnswerWriteRepository {
     private final JPAQueryFactory queryFactory;
 
-    public long update(Long programmerId, Long answerId, AnswerUpdateRequest dto) {
+    public long update(String loginId, Long answerId, AnswerUpdateRequest dto) {
         return queryFactory.update(answer)
                 .where(
                         answer.id.eq(answerId),
-                        answer.programmer.id.eq(programmerId)
+                        answer.programmer.loginId.eq(loginId)
                 )
                 .set(answer.code, dto.code() == null ? null : dto.code())
                 .set(answer.languageType, dto.languageType() == null ? null : dto.languageType())

--- a/src/main/java/com/codingmate/answer/service/AnswerService.java
+++ b/src/main/java/com/codingmate/answer/service/AnswerService.java
@@ -42,22 +42,22 @@ public class AnswerService {
     /**
      * 새로운 Answer를 생성합니다.
      *
-     * @param programmerId Answer를 작성할 Programmer의 ID
+     * @param username Answer를 작성할 Programmer의 ID
      * @param request      생성할 Answer의 내용을 담은 DTO
      * @return 생성된 Answer의 ID를 포함하는 응답 DTO
      * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 Programmer를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional
-    public AnswerCreateResponse create(Long programmerId, AnswerCreateRequest request) {
-        log.debug("[AnswerService] create({}, {})", programmerId, request.toString());
+    public AnswerCreateResponse create(String username, AnswerCreateRequest request) {
+        log.debug("[AnswerService] create({}, {})", username, request.toString());
 
-        log.info("[AnswerService] Attempting to read Programmer: {}", programmerId);
-        var writer = defaultProgrammerRepository.findById(programmerId)
+        log.info("[AnswerService] Attempting to read Programmer: {}", username);
+        var writer = defaultProgrammerRepository.findByLoginId(username)
                 .orElseThrow(() -> {
-                    log.warn("[AnswerService] Programmer not found with ID: {}", programmerId);
+                    log.warn("[AnswerService] Programmer not found with ID: {}", username);
                     return new NotFoundProgrammerException(
                             ErrorMessage.NOT_FOUND_PROGRAMMER,
-                            String.format("ID %d를 가진 Programmer를 찾을 수 없습니다.", programmerId)
+                            String.format("ID %d를 가진 Programmer를 찾을 수 없습니다.", username)
                     );
                 });
         log.debug("[AnswerService] Programmer found: {}", writer.getId());
@@ -74,15 +74,15 @@ public class AnswerService {
      * 특정 Answer의 상세 정보를 조회하고, 현재 Programmer의 해당 Answer에 대한 좋아요 여부를 반환합니다.
      *
      * @param answerId   조회할 Answer의 ID
-     * @param programmerId 현재 요청을 보낸 Programmer의 ID (좋아요 여부 확인용)
+     * @param username 현재 요청을 보낸 Programmer의 ID (좋아요 여부 확인용)
      * @return Answer 상세 정보와 좋아요 여부를 포함하는 응답 DTO
      * @throws NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional(readOnly = true)
-    public AnswerPageResponse read(Long answerId, Long programmerId) {
-        log.debug("[AnswerService] read({}, {})", answerId, programmerId);
+    public AnswerPageResponse read(Long answerId, String username) {
+        log.debug("[AnswerService] read({}, {})", answerId, username);
 
-        log.info("[AnswerService] Attempting to read Answer with ID: {} for programmer ID: {}", answerId, programmerId);
+        log.info("[AnswerService] Attempting to read Answer with ID: {} for programmer ID: {}", answerId, username);
         var answer = readRepository.read(answerId)
                 .orElseThrow(() -> {
                     log.warn("[AnswerService] Answer not found with ID: {}", answerId);
@@ -94,9 +94,9 @@ public class AnswerService {
         log.debug("[AnswerService] Answer found: {}", answer.getId()); // 또는 answer.getTitle() 등 핵심 필드
 
         boolean isLiked = likeRepository.existsByProgrammerAndAnswer(answer.getProgrammer(), answer);
-        log.debug("[AnswerService] Programmer {}'s like status for answer {}: {}", programmerId, answerId, isLiked);
+        log.debug("[AnswerService] Programmer {}'s like status for answer {}: {}", username, answerId, isLiked);
 
-        return AnswerPageResponse.of(answer, programmerId, isLiked);
+        return AnswerPageResponse.of(answer, username, isLiked);
     }
 
     /**
@@ -121,14 +121,14 @@ public class AnswerService {
      *
      * @param languageType 프로그래밍 언어 타입으로 필터링 (선택 사항)
      * @param backjoonId   백준 문제 ID로 필터링 (선택 사항)
-     * @param programmerId Answer 작성자 Programmer의 ID
+     * @param loginId Answer 작성자 Programmer의 ID
      * @param pageable     페이지네이션 정보 (페이지 번호, 페이지 크기, 정렬 등)
      * @return 필터링된 Answer 목록의 페이지 응답 DTO
      */
     @Transactional(readOnly = true)
-    public Page<AnswerListResponse> readAllByProgrammerId(LanguageType languageType, Long backjoonId, Long programmerId, Pageable pageable) {
+    public Page<AnswerListResponse> readAllByProgrammerId(LanguageType languageType, Long backjoonId, String loginId, Pageable pageable) {
         log.debug("[AnswerService] readAllByProgrammerId({}, {})", languageType, backjoonId);
-        var result = readRepository.readAllByProgrammerId(languageType, backjoonId, programmerId, pageable);
+        var result = readRepository.readAllByProgrammerId(languageType, backjoonId, loginId, pageable);
         log.debug("[AnswerService] Answer list fetched. Total elements: {}, Page size: {}", result.getTotalElements(), result.getSize());
 
         return result;
@@ -137,20 +137,20 @@ public class AnswerService {
     /**
      * 특정 Answer의 내용을 수정합니다.
      *
-     * @param programmerId 수정 요청을 보낸 Programmer의 ID (권한 확인용)
+     * @param username 수정 요청을 보낸 Programmer의 ID (권한 확인용)
      * @param answerId     수정할 Answer의 ID
      * @param request      업데이트할 내용을 담은 DTO
      * @throws NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없거나, 수정 권한이 없을 경우 발생합니다.
      */
     @Transactional
-    public void update(Long programmerId, Long answerId, AnswerUpdateRequest request) {
-        log.debug("[AnswerService] update({}, {})", programmerId, answerId);
+    public void update(String username, Long answerId, AnswerUpdateRequest request) {
+        log.debug("[AnswerService] update({}, {})", username, answerId);
 
         log.debug("[AnswerService] Attempting to update answer with ID: {}", answerId);
-        long changedRowNumber = writeRepository.update(programmerId, answerId, request);
+        long changedRowNumber = writeRepository.update(username, answerId, request);
 
         if (changedRowNumber != 1) {
-            log.warn("[AnswerService] Answer update failed: No answer found or authorized for answerId: {} and programmerId: {}. Changed rows: {}", answerId, programmerId, changedRowNumber);
+            log.warn("[AnswerService] Answer update failed: No answer found or authorized for answerId: {} and programmerId: {}. Changed rows: {}", answerId, username, changedRowNumber);
             throw new NotFoundAnswerException(
                     ErrorMessage.NOT_FOUND_ANSWER,
                     String.format("요청한 Answer ID %d를 찾을 수 없거나, 수정 권한이 없습니다.", answerId)
@@ -163,14 +163,14 @@ public class AnswerService {
      * 특정 Answer를 삭제합니다.
      * 삭제는 해당 Answer를 작성한 Programmer만 수행할 수 있습니다.
      *
-     * @param programmerId 삭제 요청을 보낸 Programmer의 ID
+     * @param username 삭제 요청을 보낸 Programmer의 ID
      * @param answerId     삭제할 Answer의 ID
      * @throws NotFoundAnswerException 지정된 {@code answerId}를 가진 Answer를 찾을 수 없을 경우 발생합니다.
      * @throws AnswerAndProgrammerDoNotMatchException 삭제 요청을 보낸 Programmer가 해당 Answer의 작성자가 아닐 경우 발생합니다.
      */
     @Transactional
-    public void delete(Long programmerId, Long answerId) {
-        log.debug("[AnswerService] delete({}, {})", programmerId, answerId);
+    public void delete(String username, Long answerId) {
+        log.debug("[AnswerService] delete({}, {})", username, answerId);
 
         log.info("[AnswerService] Attempting to delete answer with ID: {}", answerId);
         log.debug("[AnswerService] Retrieving answer with ID: {}", answerId);
@@ -183,16 +183,16 @@ public class AnswerService {
                 });
         log.debug("[AnswerService] Answer with ID {} found. Author: {}", answer.getId(), answer.getProgrammer().getId());
 
-        log.info("[AnswerService] Verifying if programmer {} owns answer {}.", programmerId, answerId);
-        if (answer.getProgrammer().getId().equals(programmerId)) {
-            log.info("[AnswerService] Programmer {} is authorized to delete answer {}. Proceeding with deletion.", programmerId, answerId);
+        log.info("[AnswerService] Verifying if programmer {} owns answer {}.", username, answerId);
+        if (answer.getProgrammer().getLoginId().equals(username)) {
+            log.info("[AnswerService] Programmer {} is authorized to delete answer {}. Proceeding with deletion.", username, answerId);
             defaultAnswerRepository.delete(answer);
-            log.info("[AnswerService] Answer with ID {} deleted successfully by programmer {}.", answerId, programmerId);
+            log.info("[AnswerService] Answer with ID {} deleted successfully by programmer {}.", answerId, username);
         } else {
-            log.warn("[AnswerService] Answer deletion failed: Programmer {} does not own answer {}. Unauthorized attempt.", programmerId, answerId);
+            log.warn("[AnswerService] Answer deletion failed: Programmer {} does not own answer {}. Unauthorized attempt.", username, answerId);
             throw new AnswerAndProgrammerDoNotMatchException(
                     ErrorMessage.ANSWER_AND_PROGRAMMER_DO_NOT_MATCH,
-                    String.format("Programmer ID %d가 삭제 요청한 Answer ID %d는 요청자가 작성한 Answer가 아닙니다.", programmerId, answerId)
+                    String.format("Programmer ID %d가 삭제 요청한 Answer ID %d는 요청자가 작성한 Answer가 아닙니다.", username, answerId)
             );
         }
     }

--- a/src/main/java/com/codingmate/auth/service/LoginService.java
+++ b/src/main/java/com/codingmate/auth/service/LoginService.java
@@ -8,6 +8,7 @@ import com.codingmate.programmer.repository.ProgrammerReadRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/codingmate/auth/service/TokenService.java
+++ b/src/main/java/com/codingmate/auth/service/TokenService.java
@@ -5,6 +5,7 @@ import com.codingmate.jwt.TokenProvider;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 /**
@@ -21,16 +22,11 @@ public class TokenService {
     /**
      * 사용자 ID와 권한을 기반으로 Access Token과 Refresh Token을 생성합니다.
      *
-     * @param id 토큰을 생성할 사용자의 ID
-     * @param authority 토큰에 포함될 사용자의 권한
      * @return 생성된 Access Token과 Refresh Token을 담은 TokenDto
      */
-    public TokenResponse generateToken(Long id, String authority) {
-        log.debug("[TokenService] generateToken - Request to generate tokens for user ID: {}, authority: {}", id, authority);
-
-        log.info("[TokenService] Generating new access and refresh tokens for user ID: {}", id);
-        String accessToken = tokenProvider.createAccessToken(id, authority);
-        var refreshTokenResult = tokenProvider.createRefreshToken(id);
+    public TokenResponse generateToken(Authentication authentication){
+        String accessToken = tokenProvider.createAccessToken(authentication);
+        var refreshTokenResult = tokenProvider.createRefreshToken(authentication.getName());
 
         var tokenDto = new TokenResponse(
                 accessToken,
@@ -39,7 +35,7 @@ public class TokenService {
                 refreshTokenResult.issuedAt()
         );
 
-        log.info("[TokenService] Tokens successfully generated for user ID: {}", id);
+        log.info("[TokenService] Tokens successfully generated for username: {}", authentication.getName());
         log.debug("[TokenService] Generated Access Token (prefix): {}, Refresh Token (prefix): {}",
                 accessToken.substring(20), // 앞부분만 로깅
                 refreshTokenResult.refreshToken().substring(20)

--- a/src/main/java/com/codingmate/auth/service/UserDetailLoginService.java
+++ b/src/main/java/com/codingmate/auth/service/UserDetailLoginService.java
@@ -1,0 +1,45 @@
+package com.codingmate.auth.service;
+
+import com.codingmate.programmer.domain.Programmer;
+import com.codingmate.programmer.repository.DefaultProgrammerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailLoginService implements UserDetailsService {
+    private final DefaultProgrammerRepository defaultProgrammerRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return defaultProgrammerRepository.findOneWithAuthoritiesByLoginId(username)
+                .map(this::createUser)
+                .orElseThrow(() -> new UsernameNotFoundException(username));
+    }
+
+    private User createUser(Programmer programmer) {
+
+        return new org.springframework.security.core.userdetails.User(
+                programmer.getLoginId(),
+                programmer.getPassword(),
+                createAuthorities(programmer)
+        );
+    }
+
+    private List<GrantedAuthority> createAuthorities(Programmer programmer) {
+        return programmer.getAuthorities().stream()
+                .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/codingmate/config/SecurityConfig.java
+++ b/src/main/java/com/codingmate/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.codingmate.config;
 
+import com.codingmate.auth.service.UserDetailLoginService;
 import com.codingmate.jwt.JwtAccessDeniedHandler;
 import com.codingmate.jwt.JwtAuthenticationEntryPoint;
 import com.codingmate.jwt.TokenProvider;
@@ -8,12 +9,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.filter.CorsFilter;
@@ -41,6 +45,16 @@ public class SecurityConfig {
     private final TokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final UserDetailLoginService userDetailLoginService;
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http, PasswordEncoder passwordEncoder) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class)
+                .userDetailsService(userDetailLoginService)
+                .passwordEncoder(passwordEncoder)
+                .and()
+                .build();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/codingmate/controller/api/AuthController.java
+++ b/src/main/java/com/codingmate/controller/api/AuthController.java
@@ -15,6 +15,7 @@ import com.codingmate.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -114,15 +117,15 @@ public class AuthController {
         return ResponseDto.toResponseEntity(ResponseMessage.SUCCESS);
     }
 
-
+    @RolesAllowed("hasRole('ROLE_USER')")
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 시도합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공."),
             @ApiResponse(responseCode = "401", description = "유효한 사용자가 아니기에 탈퇴하지 못했습니다.")
     })
     @DeleteMapping("/me")
-    public ResponseEntity<?> withdrawal(HttpServletRequest request) {
-        programmerService.delete(JwtUtil.getId(request));
+    public ResponseEntity<?> withdrawal(@AuthenticationPrincipal UserDetails userDetails) {
+        programmerService.delete(userDetails.getUsername());
         return ResponseDto.toResponseEntity(ResponseMessage.NO_CONTENT);
     }
 

--- a/src/main/java/com/codingmate/controller/api/AuthController.java
+++ b/src/main/java/com/codingmate/controller/api/AuthController.java
@@ -6,7 +6,6 @@ import com.codingmate.common.response.ResponseMessage;
 import com.codingmate.auth.dto.request.LoginRequest;
 import com.codingmate.config.properties.JWTProperties;
 import com.codingmate.programmer.dto.request.ProgrammerCreateRequest;
-import com.codingmate.auth.service.LoginService;
 import com.codingmate.programmer.service.ProgrammerService;
 import com.codingmate.refreshtoken.dto.request.RefreshTokenCreateRequest;
 import com.codingmate.refreshtoken.service.RefreshService;
@@ -42,7 +41,6 @@ public class AuthController {
     public AuthController(
             ProgrammerService programmerService,
             RefreshService refreshService,
-            LoginService loginService,
             TokenService tokenService,
             JWTProperties jwtProperties,
             RefreshTokenService refreshTokenService,

--- a/src/main/java/com/codingmate/controller/api/LikeController.java
+++ b/src/main/java/com/codingmate/controller/api/LikeController.java
@@ -5,11 +5,14 @@ import com.codingmate.common.response.ResponseMessage;
 import com.codingmate.util.JwtUtil;
 import com.codingmate.like.dto.response.LikeResponse;
 import com.codingmate.like.service.LikeService;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -19,14 +22,15 @@ import org.springframework.web.bind.annotation.*;
 public class LikeController {
     private final LikeService likeService;
 
+    @RolesAllowed("hasRole('ROLE_USER')")
     @PostMapping("/{answerId}")
     public ResponseEntity<ResponseDto<LikeResponse>> vote(
-            HttpServletRequest request,
+            @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable(name = "answerId") Long answerId
     ) {
         return ResponseDto.toResponseEntity(
                 ResponseMessage.SUCCESS,
-                likeService.toggleLike(JwtUtil.getId(request), answerId)
+                likeService.toggleLike(userDetails.getUsername(), answerId)
         );
     }
 }

--- a/src/main/java/com/codingmate/controller/api/ProgrammerController.java
+++ b/src/main/java/com/codingmate/controller/api/ProgrammerController.java
@@ -9,11 +9,14 @@ import com.codingmate.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -37,6 +40,7 @@ public class ProgrammerController {
     }
 
 
+    @RolesAllowed("hasRole('ROLE_USER')")
     @Operation(summary = "마이페이지", description = "마이페이지 정보를 불러옵니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "마이페이지 로딩 성공."),
@@ -44,14 +48,14 @@ public class ProgrammerController {
             @ApiResponse(responseCode = "404", description = "유효한 요청이 아닙니다.")
     })
     @GetMapping("/me")
-    public ResponseEntity<ResponseDto<MyPageResponse>> myPage(HttpServletRequest request) {
+    public ResponseEntity<ResponseDto<MyPageResponse>> myPage(@AuthenticationPrincipal UserDetails userDetails) {
         return ResponseDto.toResponseEntity(
                 ResponseMessage.SUCCESS,
-                programmerService.getProgrammerMyPageInfo(JwtUtil.getId(request))
+                programmerService.getProgrammerMyPageInfo(userDetails.getUsername())
         );
     }
 
-
+    @RolesAllowed("hasRole('ROLE_USER')")
     @Operation(summary = "유저 정보 수정", description = "유저 정보 수정을 시도합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "수정 성공."),
@@ -61,9 +65,9 @@ public class ProgrammerController {
     @PatchMapping("/me")
     public ResponseEntity<?> update(
             @RequestBody ProgrammerUpdateRequest programmerUpdateRequest,
-            HttpServletRequest request
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
-        programmerService.update(JwtUtil.getId(request), programmerUpdateRequest);
+        programmerService.update(userDetails.getUsername(), programmerUpdateRequest);
 
         return ResponseDto.toResponseEntity(ResponseMessage.SUCCESS);
     }

--- a/src/main/java/com/codingmate/controller/api/RankingApiController.java
+++ b/src/main/java/com/codingmate/controller/api/RankingApiController.java
@@ -5,6 +5,7 @@ import com.codingmate.ranking.service.RankingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.annotation.security.RolesAllowed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ public class RankingApiController {
 
     private final RankingService rankingService;
 
+    @RolesAllowed("hasRole('ROLE_ADMIN')")
     @Operation(summary = "Redis에 등록된 오늘의 랭킹을 읽어온다.", description = "Redis에 등록된 오늘의 랭킹을 읽어온다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Redis에서 랭킹 조회 성공"),
@@ -30,6 +32,7 @@ public class RankingApiController {
         return ResponseEntity.ok(rankingService.getRankingFromRedis());
     }
 
+    @RolesAllowed("hasRole('ROLE_ADMIN')")
     @Operation(summary = "Redis에 등록된 랭킹 재설정", description = "Redis에 등록된 랭킹을 재설정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Redis에서 랭킹 재설정 성공"),

--- a/src/main/java/com/codingmate/jwt/JwtFilter.java
+++ b/src/main/java/com/codingmate/jwt/JwtFilter.java
@@ -1,7 +1,5 @@
 package com.codingmate.jwt;
 
-import com.codingmate.exception.exception.jwt.ExpiredTokenException;
-import com.codingmate.util.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -9,13 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.StringUtils;
-import org.springframework.web.filter.GenericFilterBean;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
@@ -28,58 +23,36 @@ import java.io.IOException;
  * */
 @Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PUBLIC)
-public class JwtFilter extends GenericFilterBean { // 모든 요청에 대해 동일한 로직을 수행하는 일반 필터
+public class JwtFilter extends OncePerRequestFilter { // 모든 요청에 대해 동일한 로직을 수행하는 일반 필터
 
     private final TokenProvider tokenProvider;
 
     /**
-     * 모든 HTTP 요청에 대해 필터링 작업을 수행합니다.
-     * 요청에서 JWT를 추출하고, 유효성을 검증하며, 유효한 경우 Spring Security 컨텍스트에 인증 정보를 설정합니다.
-     * 토큰이 만료되었을 경우에는 401 Unauthorized 응답을 보냅니다.
+     * 요청이 들어오면 헤더의 토큰을 검사하고 검사 후 SecurityContextHolder에 정보를 저장해준다.
      *
-     * @param servletRequest  HTTP 요청을 나타내는 {@link ServletRequest} 객체
-     * @param servletResponse HTTP 응답을 나타내는 {@link ServletResponse} 객체
-     * @param filterChain     다음 필터 또는 서블릿으로 요청/응답을 전달하는 {@link FilterChain} 객체
-     * @throws IOException      I/O 오류 발생 시
-     * @throws ServletException 서블릿 관련 오류 발생 시
-     */
+     * @param request       토큰을 담고 있는 헤더를 가져오기 위해 사용
+     * */
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        // HTTP 요청 및 응답 객체로 캐스팅
-        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-        HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
 
-        // 1. HTTP 요청에서 JWT(Access Token)를 추출합니다.
-        String jwt = JwtUtil.getAccessToken(httpServletRequest);
-        String requestURI = httpServletRequest.getRequestURI(); // 현재 요청 URI
-
-        log.debug("[JwtFilter] Processing request for URI: {}", requestURI);
-
-        try {
-            // 2. 추출된 JWT가 존재하고 유효한지 검증합니다.
-            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-                // 3. 토큰이 유효하면, 토큰에서 인증 정보를 가져와 Spring Security 컨텍스트에 저장합니다.
-                Authentication authentication = tokenProvider.getAuthentication(jwt);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("[JwtFilter] Authentication successful. Stored '{}' authentication in Security Context for URI: {}", authentication.getName(), requestURI);
-            } else {
-                // 4. JWT가 없거나 유효하지 않은 경우, Security Context에 인증 정보를 저장하지 않습니다.
-                log.debug("[JwtFilter] No valid JWT token found for URI: {}. Proceeding without authentication.", requestURI);
-            }
-            // 5. 현재 필터의 처리가 완료되었으므로, 다음 필터로 요청/응답을 전달합니다.
-            filterChain.doFilter(servletRequest, servletResponse);
-        } catch (ExpiredTokenException e) {
-            // 6. 만료된 토큰 예외가 발생하면, 클라이언트에게 401 Unauthorized 응답을 보냅니다.
-            log.info("[JwtFilter] Expired JWT token for URI: {}. Sending 401 Unauthorized response.", requestURI);
-            httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            // 만료된 토큰이므로 더 이상 필터 체인을 진행하지 않습니다.
-        } catch (Exception e) {
-            // 그 외 JWT 관련 예외 발생 시 (예: 서명 오류, 지원되지 않는 토큰 등)
-            // TokenProvider.validateToken()에서 이미 특정 예외를 던지므로, 여기서는 일반적인 오류를 처리하거나 추가 로깅을 할 수 있습니다.
-            // 현재는 ExpiredTokenException 외에는 여기서 명시적으로 잡지 않아 Spring Security의 AccessDeniedHandler 또는 ExceptionHandler로 전달됩니다.
-            log.error("[JwtFilter] An unexpected error occurred during JWT processing for URI: {}. Error: {}", requestURI, e.getMessage());
-            // 필요한 경우, 여기서도 httpServletResponse.setStatus()를 통해 특정 오류 코드를 보낼 수 있습니다.
-            throw e; // 예외를 다시 던져서 상위 핸들러에서 처리하도록 합니다.
+        String token = resolveToken(request);
+        if (token != null && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/codingmate/jwt/TokenProvider.java
+++ b/src/main/java/com/codingmate/jwt/TokenProvider.java
@@ -43,7 +43,7 @@ public class TokenProvider {
             JWTProperties jwtProperties
     ) {
         this.AUTHORITIES_KEY = jwtProperties.authorityKey();
-        this.ACCESS_TOKEN_VALIDATE_HOUR = jwtProperties.accessTokenValidityInHour();
+        this.ACCESS_TOKEN_VALIDATE_HOUR = Duration.ofHours(jwtProperties.accessTokenValidityInHour()).toMillis();
         this.REFRESH_TOKEN_VALIDATE_DAY = jwtProperties.refreshTokenExpirationDays();
         byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.secret());    // Secret 값을 Base64 디코딩하여 HMAC SHA 키로 변환합니다.
         this.KEY = Keys.hmacShaKeyFor(keyBytes);

--- a/src/main/java/com/codingmate/jwt/TokenProvider.java
+++ b/src/main/java/com/codingmate/jwt/TokenProvider.java
@@ -1,5 +1,6 @@
 package com.codingmate.jwt;
 
+import com.codingmate.auth.domain.Authority;
 import com.codingmate.config.properties.JWTProperties;
 import com.codingmate.exception.dto.ErrorMessage;
 import com.codingmate.exception.exception.jwt.ExpiredTokenException;
@@ -48,36 +49,25 @@ public class TokenProvider {
         this.KEY = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    /**
-     * 사용자 ID와 역할을 포함하는 Access Token을 생성합니다.
-     * 클레임(claims)에는 사용자 ID와 권한 정보가 포함되며, JWT 만료 시간 등이 설정됩니다.
-     *
-     * @param userId Access Token에 포함될 사용자 ID.
-     * @param role Access Token에 포함될 사용자 역할 (권한).
-     * @return 생성된 Access Token 문자열.
-     */
-    public String createAccessToken(Long userId, String role) {
-        log.debug("[TokenProvider] createAccessToken({}, {})", userId, role);
 
-        Instant issuedAt = Instant.now();
-        Claims claims = createAccessTokenClaims(userId, role);
+    public String createAccessToken(Authentication authentication) {
+        Claims claims = Jwts.claims().setSubject(authentication.getName());
 
-        String token = Jwts.builder()
+        List<String> roles = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        claims.put("auth", roles);
+
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + ACCESS_TOKEN_VALIDATE_HOUR);
+
+        return Jwts.builder()
                 .setClaims(claims)
-                .setIssuedAt(Date.from(issuedAt))
-                .setExpiration(Date.from(issuedAt.plus(Duration.ofHours(ACCESS_TOKEN_VALIDATE_HOUR))))
-                .signWith(KEY, SignatureAlgorithm.HS256)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(SignatureAlgorithm.HS256, KEY)
                 .compact();
-
-        log.info("[TokenProvider] Access Token created for userId: {}", userId);
-        return token;
-    }
-
-    private Claims createAccessTokenClaims(Long userId, String role) {
-        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
-        claims.put(AUTHORITIES_KEY, role);
-        claims.put("id", userId);
-        return claims;
     }
 
 
@@ -85,16 +75,16 @@ public class TokenProvider {
      * 사용자 ID를 포함하는 Refresh Token을 생성합니다.
      * Refresh Token은 주로 Access Token의 갱신에 사용됩니다.
      *
-     * @param userId Refresh Token에 포함될 사용자 ID.
+     * @param username Refresh Token에 포함될 사용자 ID.
      * @return 생성된 Refresh Token 문자열.
      */
-    public RefreshTokenIssueResponse createRefreshToken(Long userId) {
-        log.debug("[TokenProvider] createRefreshToken({})", userId);
+    public RefreshTokenIssueResponse createRefreshToken(String username) {
+        log.debug("[TokenProvider] createRefreshToken({})", username);
 
         Instant issuedAt = Instant.now();
         String jti = UUID.randomUUID().toString();
 
-        Claims claims = createRefreshTokenClaims(userId, jti);
+        Claims claims = createRefreshTokenClaims(username, jti);
 
         Date issuedAtDate = Date.from(issuedAt);
         Date expirationDate = Date.from(issuedAt.plus(Duration.ofDays(REFRESH_TOKEN_VALIDATE_DAY)));
@@ -106,13 +96,13 @@ public class TokenProvider {
                 .signWith(KEY, SignatureAlgorithm.HS256)
                 .compact();
 
-        log.info("[TokenProvider] Refresh Token created for userId: {}. Token length: {}", userId, refreshToken.length());
+        log.info("[TokenProvider] Refresh Token created for username: {}. Token length: {}", username, refreshToken.length());
 
         return RefreshTokenIssueResponse.of(refreshToken, jti, issuedAt);
     }
 
-    private Claims createRefreshTokenClaims(Long userId, String jti) {
-        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+    private Claims createRefreshTokenClaims(String username, String jti) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(username));
         claims.put("jti", jti);
         return claims;
     }

--- a/src/main/java/com/codingmate/like/service/LikeService.java
+++ b/src/main/java/com/codingmate/like/service/LikeService.java
@@ -31,16 +31,16 @@ public class LikeService {
      * 이미 좋아요를 눌렀다면 좋아요를 취소하고, 누르지 않았다면 좋아요를 추가합니다.
      * 트랜잭션 내에서 프로그래머와 답변을 조회하고, 좋아요 상태를 처리하며, 답변의 좋아요 수를 업데이트합니다.
      *
-     * @param programmerId 좋아요를 누르거나 취소할 프로그래머의 ID
+     * @param username 좋아요를 누르거나 취소할 프로그래머의 ID
      * @param answerId 좋아요 대상이 되는 답변의 ID
      * @return 현재 답변의 총 좋아요 수를 포함하는 {@link LikeResponse} DTO
      */
     @Transactional
-    public LikeResponse toggleLike(Long programmerId, Long answerId) {
-        log.debug("[LikeService] toggleLike({}, {})", programmerId, answerId);
+    public LikeResponse toggleLike(String username, Long answerId) {
+        log.debug("[LikeService] toggleLike({}, {})", username, answerId);
         log.debug("[LikeService] Starting toggleLike transaction.");
 
-        var programmer = programmerFinder.read(programmerId);
+        var programmer = programmerFinder.read(username);
         log.debug("[LikeService] Found Programmer: {}", programmer.getId());
 
         var answer = answerFinder.read(answerId);

--- a/src/main/java/com/codingmate/programmer/domain/Programmer.java
+++ b/src/main/java/com/codingmate/programmer/domain/Programmer.java
@@ -12,6 +12,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 
 //TODO follow 기능 추가 염두해둘 것
@@ -70,20 +71,24 @@ public class Programmer extends BaseEntity {
     @Column(name = "tip", length = 2000)
     private String tip;
 
-    @ManyToOne
-    @JoinColumn(name = "authority")
-    private Authority authority;
+    @ManyToMany
+    @JoinTable(
+            name = "programmer_authority",
+            joinColumns = {@JoinColumn(name = "programmer_id", referencedColumnName = "programmer_id")},
+            inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")}
+    )
+    private Set<Authority> authorities;
 
     @OneToMany(mappedBy = "programmer", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Like> likedAnswers = new ArrayList<>();
 
-    public static Programmer toEntity(ProgrammerCreateRequest request, Authority authority) {
+    public static Programmer toEntity(ProgrammerCreateRequest request, Set<Authority> authorities) {
         return Programmer.builder()
                 .email(new Email(request.email()))
                 .name(new Name(request.name()))
                 .githubId(request.githubId())
                 .password(request.password())
-                .authority(authority)
+                .authorities(authorities)
                 .loginId(request.loginId())
                 .tip("팁이 있다면 공유해주세요")
                 .build();

--- a/src/main/java/com/codingmate/programmer/dto/response/ProgrammerResponse.java
+++ b/src/main/java/com/codingmate/programmer/dto/response/ProgrammerResponse.java
@@ -1,8 +1,11 @@
 package com.codingmate.programmer.dto.response;
 
+import com.codingmate.auth.domain.Authority;
 import com.codingmate.programmer.domain.Programmer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+
+import java.util.Set;
 
 /**
  * 사용자의 살세 정보를 응답하기 위한 DTO
@@ -40,7 +43,7 @@ public record ProgrammerResponse(
         String tip,
 
         @Schema(description = "프로그래머의 권한 (예: ROLE_USER, ROLE_ADMIN)", example = "ROLE_USER")
-        String authority
+        Set<Authority> authority
 ) {
     /**
      * Programmer 엔티티를 사용하여 ProgrammerResponse를 생성합니다.
@@ -58,7 +61,7 @@ public record ProgrammerResponse(
                 .name(programmer.getName().getName())
                 .email(programmer.getEmail().getEmail())
                 .tip(programmer.getTip())
-                .authority(programmer.getAuthority().getAuthorityName())
+                .authority(programmer.getAuthorities())
                 .build();
     }
 }

--- a/src/main/java/com/codingmate/programmer/repository/DefaultProgrammerRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/DefaultProgrammerRepository.java
@@ -4,6 +4,7 @@ import com.codingmate.programmer.domain.Programmer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 /**
@@ -14,4 +15,7 @@ import java.util.Optional;
 @Repository
 public interface DefaultProgrammerRepository extends JpaRepository<Programmer, Long> {
     Optional<Programmer> findOneWithAuthoritiesByLoginId(String id);
+    Optional<Programmer> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+    void deleteByLoginId(String loginId);
 }

--- a/src/main/java/com/codingmate/programmer/repository/DefaultProgrammerRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/DefaultProgrammerRepository.java
@@ -13,5 +13,5 @@ import java.util.Optional;
  * */
 @Repository
 public interface DefaultProgrammerRepository extends JpaRepository<Programmer, Long> {
-    Optional<Programmer> findById(Long id);
+    Optional<Programmer> findOneWithAuthoritiesByLoginId(String id);
 }

--- a/src/main/java/com/codingmate/programmer/repository/ProgrammerReadRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/ProgrammerReadRepository.java
@@ -1,5 +1,6 @@
 package com.codingmate.programmer.repository;
 
+import com.codingmate.auth.domain.Authority;
 import com.codingmate.programmer.domain.Programmer;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.AccessLevel;
@@ -8,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.codingmate.auth.domain.QAuthority.authority;
 import static com.codingmate.programmer.domain.QProgrammer.programmer;
@@ -44,7 +46,7 @@ public class ProgrammerReadRepository {
         return Optional.ofNullable(
                 queryFactory.selectFrom(programmer)
                         .where(programmer.loginId.eq(loginId))
-                        .leftJoin(programmer.authority, authority)
+                        .leftJoin(programmer.authorities, authority)
                         .fetchJoin()
                         .fetchOne()
         );
@@ -53,13 +55,13 @@ public class ProgrammerReadRepository {
     /**
      * @implSpec fetchJoin으로 지연로딩 방지
      * */
-    public Optional<String> readProgrammerRole(Long programmerId) {
+    public Optional<Set<Authority>> readProgrammerRole(String username) {
         Programmer result = queryFactory.selectFrom(programmer)
-                .where(programmer.id.eq(programmerId))
-                .leftJoin(programmer.authority, authority)
+                .where(programmer.loginId.eq(username))
+                .leftJoin(programmer.authorities, authority)
                 .fetchJoin()
                 .fetchOne();
-        return result.getAuthority().getAuthorityName().describeConstable();
+        return Optional.ofNullable(result.getAuthorities());
     }
 
     //TODO 로그인 아이디와 비밀번호를 바꾸는 로직은 DTO 에서는 null-safe patch update DTO을 사용하도록 함.

--- a/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+import java.util.Set;
+
 import static com.codingmate.programmer.domain.QProgrammer.programmer;
 
 /**
@@ -32,7 +34,7 @@ public class ProgrammerWriteRepository {
      * @implSpec loginId가 중복되는지 여부 확인 + Programmer 등록으로 쿼리가 두 번 나감
      * @implNote em.persist는 항상 값을 반환하기 때문에 Optional을 사용하지 않는다.
      * */
-    public ProgrammerResponse create(ProgrammerCreateRequest request, Authority authority) {
+    public ProgrammerResponse create(ProgrammerCreateRequest request, Set<Authority> authority) {
         var entity = Programmer.toEntity(request, authority);
         em.persist(entity);
 

--- a/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
+++ b/src/main/java/com/codingmate/programmer/repository/ProgrammerWriteRepository.java
@@ -41,9 +41,9 @@ public class ProgrammerWriteRepository {
         return ProgrammerResponse.of(entity);
     }
 
-    public long update(Long programmerId, ProgrammerUpdateRequest dto) {
+    public long update(String loginId, ProgrammerUpdateRequest dto) {
         return queryFactory.update(programmer)
-                .where(programmer.id.eq(programmerId))
+                .where(programmer.loginId.eq(loginId))
                 .set(programmer.name.name, dto.name() == null ? null : dto.name())
                 .set(programmer.email.email, dto.email() == null ? null : dto.email())
                 .set(programmer.githubId, dto.githubId() == null ? null : dto.githubId())

--- a/src/main/java/com/codingmate/programmer/service/ProgrammerFinder.java
+++ b/src/main/java/com/codingmate/programmer/service/ProgrammerFinder.java
@@ -29,4 +29,13 @@ public class ProgrammerFinder {
                         "프로그래머를 찾을 수 없습니다.")
                 );
     }
+
+    @Transactional(readOnly = true)
+    public Programmer read(String loginId){
+        return programmerRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new NotFoundProgrammerException(
+                ErrorMessage.NOT_FOUND_PROGRAMMER,
+                "프로그래머를 찾을 수 없습니다.")
+        );
+    }
 }

--- a/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
+++ b/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
@@ -96,27 +96,27 @@ public class ProgrammerService {
     /**
      * 특정 프로그래머의 마이페이지 정보를 조회합니다.
      *
-     * @param programmerId 조회할 프로그래머의 ID
+     * @param username 조회할 프로그래머의 ID
      * @return 프로그래머의 마이페이지 정보를 담은 응답 DTO
      * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional(readOnly = true)
-    public MyPageResponse getProgrammerMyPageInfo(Long programmerId) {
-        log.info("[ProgrammerService] getProgrammerMyPageInfo({})", programmerId);
+    public MyPageResponse getProgrammerMyPageInfo(String username) {
+        log.info("[ProgrammerService] getProgrammerMyPageInfo({})", username);
 
-        log.debug("[ProgrammerService] Searching for programmer with ID: {}", programmerId);
-        var programmer = defaultProgrammerRepository.findById(programmerId)
+        log.debug("[ProgrammerService] Searching for programmer with ID: {}", username);
+        var programmer = defaultProgrammerRepository.findByLoginId(username)
                 .orElseThrow(() -> {
-                    log.warn("[ProgrammerService] MyPage info failed: Programmer not found with ID: {}", programmerId);
+                    log.warn("[ProgrammerService] MyPage info failed: Programmer not found with ID: {}", username);
                     return new NotFoundProgrammerException(
                             ErrorMessage.INVALID_ID,
-                            String.format("%d는 존재하지 않는 ProgrammerID입니다.", programmerId));
+                            String.format("%d는 존재하지 않는 ProgrammerID입니다.", username));
                 });
-        log.debug("[ProgrammerService] Programmer found: {}. Counting answers...", programmerId);
+        log.debug("[ProgrammerService] Programmer found: {}. Counting answers...", username);
 
-        long writtenAnswersCount = answerReadRepository.countProgrammerWroteAnswer(programmerId);
-        log.debug("[ProgrammerService] Programmer {} has written {} answers.", programmerId, writtenAnswersCount);
-        log.info("[ProgrammerService] Successfully retrieved MyPage info for programmerId: {}", programmerId);
+        long writtenAnswersCount = answerReadRepository.countProgrammerWroteAnswer(username);
+        log.debug("[ProgrammerService] Programmer {} has written {} answers.", username, writtenAnswersCount);
+        log.info("[ProgrammerService] Successfully retrieved MyPage info for programmerId: {}", username);
 
         return MyPageResponse.of(programmer, writtenAnswersCount);
     }
@@ -150,53 +150,53 @@ public class ProgrammerService {
     /**
      * 특정 프로그래머의 정보를 업데이트합니다.
      *
-     * @param programmerId 업데이트할 프로그래머의 ID
+     * @param username 업데이트할 프로그래머의 ID
      * @param request      업데이트할 내용을 담은 DTO
      * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional
-    public void update(Long programmerId, ProgrammerUpdateRequest request) {
-        log.info("[ProgrammerService] update({}, {})", programmerId, request);
+    public void update(String username, ProgrammerUpdateRequest request) {
+        log.info("[ProgrammerService] update({}, {})", username, request);
 
-        log.debug("[ProgrammerService] Update request details for programmerId {}: {}", programmerId, request);
+        log.debug("[ProgrammerService] Update request details for programmerId {}: {}", username, request);
 
-        long changedRows = writeRepository.update(programmerId, request);
+        long changedRows = writeRepository.update(username, request);
         if (changedRows == 0) { // 변경된 행이 0개인 경우 (찾지 못한 경우)
-            log.warn("[ProgrammerService] Update failed: Programmer not found with ID: {}. No rows changed.", programmerId);
+            log.warn("[ProgrammerService] Update failed: Programmer not found with ID: {}. No rows changed.", username);
             throw new NotFoundProgrammerException(
                     ErrorMessage.NOT_FOUND_PROGRAMMER,
-                    String.format("ID '%d'를 가진 Programmer를 찾을 수 없어 업데이트를 진행할 수 없습니다.", programmerId)
+                    String.format("ID '%d'를 가진 Programmer를 찾을 수 없어 업데이트를 진행할 수 없습니다.", username)
             );
         }
-        log.info("[ProgrammerService] Programmer with ID {} updated successfully. Changed rows: {}", programmerId, changedRows);
+        log.info("[ProgrammerService] Programmer with ID {} updated successfully. Changed rows: {}", username, changedRows);
     }
 
     /**
      * 특정 프로그래머 계정을 삭제합니다.
      * 계정 삭제 시, 해당 프로그래머가 작성한 모든 답변도 함께 삭제됩니다.
      *
-     * @param programmerId 삭제할 프로그래머의 ID
+     * @param username 삭제할 프로그래머의 ID
      * @throws NotFoundProgrammerException 지정된 {@code programmerId}를 가진 프로그래머를 찾을 수 없을 경우 발생합니다.
      */
     @Transactional
-    public void delete(Long programmerId) {
-        log.info("[ProgrammerService] delete({})", programmerId);
+    public void delete(String username) {
+        log.info("[ProgrammerService] delete({})", username);
 
-        log.debug("[ProgrammerService] Checking existence for programmer ID: {}", programmerId);
-        boolean isExist = defaultProgrammerRepository.existsById(programmerId);
+        log.debug("[ProgrammerService] Checking existence for programmer ID: {}", username);
+        boolean isExist = defaultProgrammerRepository.existsByLoginId(username);
         if (isExist) {
-            log.debug("[ProgrammerService] Programmer with ID {} exists. Proceeding with deletion.", programmerId);
+            log.debug("[ProgrammerService] Programmer with ID {} exists. Proceeding with deletion.", username);
 
-            long deletedAnswersCount = answerWriteRepository.deleteByProgrammerId(programmerId);
-            log.info("[ProgrammerService] Programmer ID {} related answers {} were deleted.", programmerId, deletedAnswersCount);
+            long deletedAnswersCount = answerWriteRepository.deleteByProgrammerId(username);
+            log.info("[ProgrammerService] Programmer ID {} related answers {} were deleted.", username, deletedAnswersCount);
 
-            defaultProgrammerRepository.deleteById(programmerId);
-            log.info("[ProgrammerService] Programmer with ID {} deleted successfully.", programmerId);
+            defaultProgrammerRepository.deleteByLoginId(username);
+            log.info("[ProgrammerService] Programmer with ID {} deleted successfully.", username);
         } else {
-            log.warn("[ProgrammerService] Delete failed: Programmer not found with ID: {}. No action taken.", programmerId);
+            log.warn("[ProgrammerService] Delete failed: Programmer not found with ID: {}. No action taken.", username);
             throw new NotFoundProgrammerException(
                     ErrorMessage.NOT_FOUND_PROGRAMMER,
-                    String.format("ID '%d'를 가진 Programmer를 찾을 수 없어 삭제를 진행할 수 없습니다.", programmerId)
+                    String.format("ID '%d'를 가진 Programmer를 찾을 수 없어 삭제를 진행할 수 없습니다.", username)
             );
         }
     }

--- a/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
+++ b/src/main/java/com/codingmate/programmer/service/ProgrammerService.java
@@ -4,7 +4,6 @@ import com.codingmate.answer.repository.AnswerReadRepository;
 import com.codingmate.answer.repository.AnswerWriteRepository;
 import com.codingmate.auth.domain.Authority;
 import com.codingmate.auth.service.AuthorityFinder;
-import com.codingmate.programmer.domain.Programmer;
 import com.codingmate.programmer.dto.request.ProgrammerCreateRequest;
 import com.codingmate.programmer.dto.request.ProgrammerUpdateRequest;
 import com.codingmate.programmer.dto.response.MyPageResponse;
@@ -187,7 +186,7 @@ public class ProgrammerService {
         if (isExist) {
             log.debug("[ProgrammerService] Programmer with ID {} exists. Proceeding with deletion.", username);
 
-            long deletedAnswersCount = answerWriteRepository.deleteByProgrammerId(username);
+            long deletedAnswersCount = answerWriteRepository.deleteByLoginId(username);
             log.info("[ProgrammerService] Programmer ID {} related answers {} were deleted.", username, deletedAnswersCount);
 
             defaultProgrammerRepository.deleteByLoginId(username);

--- a/src/main/java/com/codingmate/refreshtoken/domain/RefreshToken.java
+++ b/src/main/java/com/codingmate/refreshtoken/domain/RefreshToken.java
@@ -25,7 +25,7 @@ import java.time.Instant;
 @Table(name = "refresh_token_info",
         indexes = {
                 @Index(name = "ref_jti_idx", columnList = "jti", unique = true),
-                @Index(name = "ref_user_revoke_idx", columnList = "user_id, is_revoked")
+                @Index(name = "ref_user_revoke_idx", columnList = "username, is_revoked")
         }
 )
 @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/codingmate/refreshtoken/domain/RefreshToken.java
+++ b/src/main/java/com/codingmate/refreshtoken/domain/RefreshToken.java
@@ -18,7 +18,7 @@ import java.time.Instant;
  *     <li>issuedAt: 발급된 시간</li>
  *     <li>expiredAt: 유효기간</li>
  *     <li>isRevoked: 토큰이 사용되었는지</li>
- *     <li>userId: 발급한 사용자의 PK</li>
+ *     <li>username: 발급한 사용자의 로그인 아이디</li>
  * </ul>
  * */
 @Entity
@@ -58,8 +58,8 @@ public class RefreshToken {
     private boolean isRevoked = false; // 기본값은 false (폐기되지 않음)
 
     // 이 토큰이 속한 사용자 ID (인덱싱을 고려하면 성능에 좋음)
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @Column(name = "username", nullable = false)
+    private String username;
 
     public static RefreshToken toEntity(RefreshTokenCreateRequest request, int expireDay) {
         return RefreshToken.builder()
@@ -67,7 +67,7 @@ public class RefreshToken {
                 .jti(request.jti())
                 .issuedAt(Instant.now())
                 .expiresAt(Instant.now().plus(Duration.ofDays(expireDay)))
-                .userId(request.userId())
+                .username(request.username())
                 .build();
     }
 

--- a/src/main/java/com/codingmate/refreshtoken/dto/request/RefreshTokenCreateRequest.java
+++ b/src/main/java/com/codingmate/refreshtoken/dto/request/RefreshTokenCreateRequest.java
@@ -13,7 +13,7 @@ import java.time.Instant;
  * <li>token: 리프레쉬 토큰 전문</li>
  * <li>jti: 리프레쉬 토큰의 jti</li>
  * <li>issuedAt: 리프레쉬 토큰이 발급된 시간</li>
- * <li>userId: 리프레쉬 토큰의 사용자 아이디</li>
+ * <li>username: 리프레쉬 토큰의 사용자 아이디</li>
  *
  * @author duskafka
  * */
@@ -22,27 +22,26 @@ public record RefreshTokenCreateRequest(
         String token,
         String jti,
         Instant issuedAt,
-        Long userId
+        String username
 ) {
-    public static RefreshTokenCreateRequest of(String token, String jti, Instant issuedAt, Long userId) {
+    public static RefreshTokenCreateRequest of(String token, String jti, Instant issuedAt, String username) {
         return RefreshTokenCreateRequest.builder()
                 .token(token)
                 .jti(jti)
                 .issuedAt(issuedAt)
-                .userId(userId)
+                .username(username)
                 .build();
     }
 
     public static RefreshTokenCreateRequest of(
             RefreshTokenIssueResponse refreshToken,
-            Long id
+            String username
     ) {
-
         return RefreshTokenCreateRequest.builder()
                 .token(refreshToken.refreshToken())
                 .jti(refreshToken.jti())
                 .issuedAt(refreshToken.issuedAt())
-                .userId(id)
+                .username(username)
                 .build();
     }
 }

--- a/src/main/java/com/codingmate/refreshtoken/dto/response/RefreshTokenResponse.java
+++ b/src/main/java/com/codingmate/refreshtoken/dto/response/RefreshTokenResponse.java
@@ -17,7 +17,7 @@ import java.time.Instant;
  * <li>issuedAt: 리프레쉬 토큰의 발급 시간</li>
  * <li>expiredAt: 리프레쉬 토큰의 유효 시간</li>
  * <li>isRevoked: 리프레쉬 토큰이 사용되어서 유효한지</li>
- * <li>userId: 리프레쉬 토큰의 사용자 아이디</li>
+ * <li>username: 리프레쉬 토큰의 사용자 아이디</li>
  *
  * @author duskafka
  * */
@@ -29,7 +29,7 @@ public record RefreshTokenResponse(
         Instant issuedAt,
         Instant expiresAt,
         boolean isRevoked,
-        Long userId
+        String username
 ) {
     public static RefreshTokenResponse of(RefreshToken refreshToken) {
         return RefreshTokenResponse.builder()
@@ -39,7 +39,7 @@ public record RefreshTokenResponse(
                 .issuedAt(refreshToken.getIssuedAt())
                 .expiresAt(refreshToken.getExpiresAt())
                 .isRevoked(refreshToken.isRevoked())
-                .userId(refreshToken.getUserId())
+                .username(refreshToken.getUsername())
                 .build();
     }
 }

--- a/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenReadRepository.java
+++ b/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenReadRepository.java
@@ -20,12 +20,12 @@ import static com.codingmate.refreshtoken.domain.QRefreshToken.refreshToken;
 public class RefreshTokenReadRepository {
     private final JPAQueryFactory queryFactory;
 
-    public long countRefreshToken(Long userId) {
+    public long countRefreshToken(String username) {
         Long count = queryFactory
                 .select(refreshToken.count())
                 .from(refreshToken)
                 .where(
-                        refreshToken.userId.eq(userId),
+                        refreshToken.username.eq(username),
                         refreshToken.isRevoked.eq(false)
                 )
                 .fetchOne();

--- a/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenRepository.java
@@ -13,6 +13,6 @@ import java.util.Optional;
  * */
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    List<RefreshToken> findByUserId(Long userId);
+    List<RefreshToken> findByUsername(String userId);
     Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenWriteRepository.java
+++ b/src/main/java/com/codingmate/refreshtoken/repository/RefreshTokenWriteRepository.java
@@ -18,10 +18,10 @@ import static com.codingmate.refreshtoken.domain.QRefreshToken.refreshToken;
 public class RefreshTokenWriteRepository {
     private final JPAQueryFactory queryFactory;
 
-    public long revokeAllToken(Long userId) {
+    public long revokeAllToken(String username) {
         return queryFactory.update(refreshToken)
                 .where(
-                        refreshToken.userId.eq(userId),
+                        refreshToken.username.eq(username),
                         refreshToken.isRevoked.eq(false)
                 )
                 .set(refreshToken.isRevoked, true)

--- a/src/main/java/com/codingmate/refreshtoken/service/validate/JtiValidator.java
+++ b/src/main/java/com/codingmate/refreshtoken/service/validate/JtiValidator.java
@@ -29,17 +29,17 @@ public class JtiValidator {
      *
      * @param tokenJti 사용자의 쿠키에서 가져온 토큰의 jti
      * @param redisJti redis에 저장되어있는 jti
-     * @param programmerId 사용자의 쿠키에서 가져온 토큰의 programmerId
+     * @param username 사용자의 쿠키에서 가져온 토큰의 programmerId
      * */
     public void validateJti(
             String tokenJti,
             String redisJti,
-            Long programmerId
+            String username
     ) {
-        log.debug("[RefreshService] validateJti({}, {}, {})", tokenJti, redisJti, programmerId);
+        log.debug("[RefreshService] validateJti({}, {}, {})", tokenJti, redisJti, username);
 
         validateJtiEquality(tokenJti, redisJti);
-        validateJtiReusability(tokenJti, programmerId);
+        validateJtiReusability(tokenJti, username);
         log.info("[RefreshService] jti not revoked");
     }
 
@@ -60,10 +60,10 @@ public class JtiValidator {
      *
      * @exception RefreshTokenIsRevoked 이미 사용된 jti라면 예외를 발생시킨다
      * */
-    private void validateJtiReusability(String jti, Long userId) {
+    private void validateJtiReusability(String jti, String username) {
         if (refreshTokenService.isUsedJti(jti)) {
-            log.warn("[RefreshService] Reused JTI. All tokens revoked for user: {}", userId);
-            refreshTokenService.revokeAllToken(userId);
+            log.warn("[RefreshService] Reused JTI. All tokens revoked for user: {}", username);
+            refreshTokenService.revokeAllToken(username);
             throw new RefreshTokenIsRevoked(
                     ErrorMessage.REFRESH_TOKEN_REVOKED,
                     "요청한 리프레시 토큰은 이미 사용된 토큰입니다. 보안 상 이유로 모든 토큰을 무효화합니다."

--- a/src/main/java/com/codingmate/util/JwtUtil.java
+++ b/src/main/java/com/codingmate/util/JwtUtil.java
@@ -35,14 +35,13 @@ public class JwtUtil {
         return (Long) getAllClaims(token).get("id");
     }
 
-    public static Long getIdFromSubject(String refreshToken) {
-        return Long.valueOf(
-                Jwts.parser()
-                        .setSigningKey(SECRET)
-                        .parseClaimsJws(refreshToken)
-                        .getBody()
-                        .getSubject()
-        );
+    public static String getUsername(String refreshToken) {
+        return Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(refreshToken)
+                .getBody()
+                .getSubject();
+
     }
 
     public static String getJti(String refreshToken) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   # 스프링 JPA 설정
   jpa:
     hibernate:
-      ddl-auto: update                               # DB 테이블 생성 전략 설정
+      ddl-auto: create                               # DB 테이블 생성 전략 설정
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect # MySQL 8.x용 Dialect
@@ -17,7 +17,7 @@ spring:
     defer-datasource-initialization: true            # SQL 스크립트 초기화를 JPA 앤티티 매니저 초기화 이후로 지연시킨다. 이는 data.sql이 있어서 필요하다.
   sql:
     init:
-    # mode: always                                    # SQL 초기화 스크립트를 언제 실행할지 결정한다.
+     mode: always                                    # SQL 초기화 스크립트를 언제 실행할지 결정한다.
   # Redis 설정
   data:
     redis:
@@ -51,10 +51,12 @@ jwt:
   access-token-validity-in-hour: 3      # 액세스 토큰 유효기간 (시간)
   refresh-token-cookie: code-mate-ref   # 리프레시 토큰 쿠키 키
   refresh-token-expiration-days: 60     # 리프레시 토큰 유효기간 (일)
+  authority-key: auth                   # 액세스 토큰에서 권한을 가져올 키
   redis:                                # Redis
     key:
       prefix: programmer                # 레디스 저장에 필요한 키 값 중 접두어
       suffix: token_rts                 # 레디스 저장에 필요한 키 값 중 접미어
+    max-token: 3                        # 최대로 발급 가능한 토큰의 수
 
 # 랭킹 Redis 저장 설정
 ranking:

--- a/src/main/resources/static/js/create_header.js
+++ b/src/main/resources/static/js/create_header.js
@@ -5,7 +5,7 @@ function create_header() {
     };
 
     if (authToken) {
-        headers['Authorization'] = `${authToken}`;
+        headers['Authorization'] = `Bearer ${authToken}`;
     }
 
     return headers

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -120,7 +120,7 @@
         const navLeft = navElement.querySelector('.nav-left');
         const navRight = navElement.querySelector('.nav-right');
 
-        if (localStorage.getItem('Coding-Mate-Auth')) {
+        if (localStorage.getItem('Authorization')) {
             navLeft.innerHTML = `
                 <a href="/">홈</a>
                 <a href="/answer/list">풀이 목록</a>

--- a/src/main/resources/templates/programmer/my_page.html
+++ b/src/main/resources/templates/programmer/my_page.html
@@ -197,6 +197,7 @@
 <script>
     document.addEventListener('DOMContentLoaded', async function () {
         console.log('DOMContentLoaded 시작');
+        await check_and_refresh_token_for_nav_bar();
         try {
             const responseData = await fetchDataWithAuth('/api/v1/programmer/me');
             console.log('받아온 데이터:', responseData);

--- a/src/main/resources/templates/un_used/answer.html
+++ b/src/main/resources/templates/un_used/answer.html
@@ -120,7 +120,8 @@
         <button onclick="delete_answer()" id="deleteButton">삭제</button>
     </div>
 </div>
-
+<script src="/js/auth.js" defer></script>
+<script src="/js/create_header.js"></script>
 <script>
     //로그인 여부에 따라 navbar가 바뀌도록 함
     document.addEventListener('DOMContentLoaded', function () {
@@ -144,123 +145,6 @@
                 // 필요한 경우 에러 메시지 표시 또는 다른 동작 수행
             });
     });
-
-    async function check_and_refresh_token_for_nav_bar() {
-        console.log('checkAndRefreshAccessTokenForNavbar');
-        const accessToken = localStorage.getItem('Coding-Mate-Auth');
-        const refreshToken = localStorage.getItem('Coding-Mate-Auth-Ref');
-        const navElement = document.getElementById('mainNav');
-        const navLeft = navElement.querySelector('.nav-left');
-        const navRight = navElement.querySelector('.nav-right');
-
-        if (accessToken) {
-
-            const response = await fetch('/api/v1/auth/tokens', {
-                method: 'GET',
-                headers: {
-                    'Coding-Mate-Auth': accessToken
-                }
-            });
-
-            if (response.ok) {
-                update_navbar_authenticated(navLeft, navRight);
-                return true;
-            } else if (response.status === 401 && refreshToken) {
-                const refreshResult = await refresh_access_token();
-                if (refreshResult) {
-                    update_navbar_authenticated(navLeft, navRight);
-                    return true;
-                }
-            }
-        }
-    }
-
-    async function refresh_access_token() {
-        const refreshToken = localStorage.getItem('Coding-Mate-Auth-Ref');
-        if (!refreshToken) {
-            console.log('Refresh Token이 없습니다.');
-            return false;
-        }
-        try {
-            const refreshResponse = await fetch('/api/v1/auth/tokens', {
-                method: 'POST',
-                headers: {
-                    'Coding-Mate-Auth-Ref': `${refreshToken}`
-                }
-            });
-
-            if (refreshResponse.ok) {
-                const newTokenData = await refreshResponse.json();
-                if (newTokenData && newTokenData.data && newTokenData.data.accessToken && newTokenData.data.refreshToken) {
-                    localStorage.setItem('Coding-Mate-Auth', newTokenData.data.accessToken);
-                    localStorage.setItem('Coding-Mate-Auth-Ref', newTokenData.data.refreshToken);
-                    console.log('토큰 갱신 성공:', newTokenData.data);
-                    return true;
-                } else {
-                    console.error('새로운 토큰 응답에 accessToken 또는 refreshToken 없음:', newTokenData);
-                    localStorage.removeItem('Coding-Mate-Auth');
-                    localStorage.removeItem('Coding-Mate-Auth-Ref');
-                    return false;
-                }
-            } else {
-                console.error('Refresh Token 요청 실패:', refreshResponse.status);
-                localStorage.removeItem('Coding-Mate-Auth');
-                localStorage.removeItem('Coding-Mate-Auth-Ref');
-                return false;
-            }
-        } catch (error) {
-            console.error('Refresh Token 요청 중 오류:', error);
-            localStorage.removeItem('Coding-Mate-Auth');
-            localStorage.removeItem('Coding-Mate-Auth-Ref');
-            return false;
-        }
-    }
-
-    function update_navbar_authenticated(navLeft, navRight) {
-        navLeft.innerHTML = `
-        <a href="/">홈</a>
-        <a href="/answer/list">풀이 목록</a>
-    `;
-        navRight.innerHTML = `
-        <a href="/my-page">프로필</a>
-        <a href="#" id="logoutButton">로그아웃</a>
-    `;
-
-        const logoutButton = document.getElementById('logoutButton');
-        if (logoutButton) {
-            logoutButton.addEventListener('click', function (event) {
-                event.preventDefault(); // <a> 태그의 기본 동작(페이지 이동) 방지
-                logout(); // 로그아웃 함수 호출 (이전에 정의한 함수)
-            });
-        }
-    }
-
-    function logout() {
-        fetch('/api/v1/auth/sign-out', { // 서버의 로그아웃 엔드포인트로 요청
-            method: 'DELETE',
-            headers: {
-                //'Content-Type': 'application/json' // 필요한 경우 Content-Type 설정
-                // 필요한 경우 인증 헤더 (Authorization 등)를 포함할 수 있습니다.
-                'Coding-Mate-Auth-Ref': localStorage.getItem('Coding-Mate-Auth-Ref')
-            }
-            // body는 일반적으로 필요하지 않습니다.
-        })
-            .then(response => {
-                if (response.ok) {
-                    localStorage.removeItem('Coding-Mate-Auth');
-                    localStorage.removeItem('Coding-Mate-Auth-Ref');
-                    alert('로그아웃 되었습니다.');
-                    window.location.href = '/login'; // 로그인 페이지로 리다이렉트
-                } else {
-                    console.error('로그아웃 실패:', response.status);
-                    alert('로그아웃에 실패했습니다.');
-                }
-            })
-            .catch(error => {
-                console.error('로그아웃 요청 실패:', error);
-                alert('로그아웃 요청에 실패했습니다.');
-            });
-    }
 
     function get_answer_id_from_url() {
         // URL이 /answer/{answerId} 형태일 때 '{answerId}' 부분을 반환
@@ -361,19 +245,6 @@
                 alert(error.message || '풀이 삭제 요청 중 오류가 발생했습니다.');
             }
         }
-    }
-
-    function create_header() {
-        const authToken = localStorage.getItem('Coding-Mate-Auth');
-        const headers = {
-            'Content-Type': 'application/json' // JSON 형식으로 보낼 때 Content-Type 설정
-        };
-
-        if (authToken) {
-            headers['Coding-Mate-Auth'] = `${authToken}`;
-        }
-
-        return headers
     }
 </script>
 </body>


### PR DESCRIPTION
### 📝 요약 (Summary)

이 PR은 기존에 사용하지 않던 Spring Security의 SecurityContextHolder를 사용해서 애플리케이션 보안을 담당하도록 하였습니다.

---

### 🚀 변경 배경 및 문제점 (Motivation / Problem Solved)

기존의 로직은 JwtUtils에서 id를 가져와서 로직을 처리했는데 이렇게 할 경우 사용자의 PK가 그대로 노출될 수 있는 위험을 가졌습니다. 이를 해결하기 위해 유저의 아이디를 사용하여 서비스를 이용할 수 있도록 로직을 수정하였으며 SecurityContextHolder에서 인증된 정보를 가져와서 사용할 수 있도록 하였습니다.

---

### 🛠️ 변경 내용 상세 (Changes Made)

* JwtFilter: Authorization 헤더에서 토큰을 추출하여 인증 정보를 SecurityContextHolder에 저장합니다.
* TokenProvider: 기존에 programmer_id(Long)으로 생성하던 토큰을 이제는 Authentication 을 사용해서 토큰을 발급하도록 변경하였습니다.
* 그 외의 서비스 및 레포지토리: 기존에 PK를 매개변수로 받고 사용하던 메소드들을 유저의 아이디를 받아서 사용할 수 있도록 변경하였습니다.
* 컨트롤러: 컨트롤러에 `@RolesAllowed`를 사용하여 ROLE에 따른 제약을 두었으며, HttpServletRequest에서 토큰을 뽑던 것을 `@AuthenticaionPrincipal`을 사용해서 `UserDetails`를 사용하여 정보를 얻을 수 있도록 하였습니다.


---

### 💡 구현 세부 사항 및 기술적 결정 (Implementation Details / Technical Decisions)

* 기존에는 사용하지 않던 SecurityContextHolder를 사용하여 인증 정보를 저장합니다.
* `@AuthenticationPrincipal`을 사용하여 인증 정보를 가져옵니다.
